### PR TITLE
isolate sliver handling to a recipe step

### DIFF
--- a/code/modules/cooking/cooking_container.dm
+++ b/code/modules/cooking/cooking_container.dm
@@ -315,20 +315,6 @@
 	preposition = "On"
 	materials = list(MAT_WOOD = 5)
 
-// For very carefully making the most powerful sandwich in the universe.
-/obj/item/reagent_containers/cooking/board/item_interaction(mob/living/user, obj/item/used, list/modifiers)
-	if(istype(used, /obj/item/retractor/supermatter))
-		var/obj/item/retractor/supermatter/tongs = used
-		if(tongs.sliver)
-			tongs.sliver.melee_attack_chain(user, src)
-			if(tongs.sliver.loc != tongs)
-				tongs.sliver = null
-				// TODO: refactor the tongs so they actually check if(sliver) in `update_icon()` instead of manually setting the icons everywhere.
-				tongs.icon_state = "supermatter_tongs"
-				used.update_appearance(UPDATE_ICON)
-			return ITEM_INTERACT_COMPLETE
-	..()
-
 /obj/item/reagent_containers/cooking/sushimat
 	name = "Sushi Mat"
 	desc = "A wooden mat used for efficient sushi crafting."

--- a/code/modules/cooking/recipes/cutting_board_recipes.dm
+++ b/code/modules/cooking/recipes/cutting_board_recipes.dm
@@ -444,13 +444,39 @@
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/bread),
 	)
 
+/// A step that allows either direct adding of a supermatter sliver
+/// (if you have somehow manage to hold one), or
+/// from tongs if those are used and contain a sliver in them.
+/datum/cooking/recipe_step/add_item/supermatter_sliver
+
+/datum/cooking/recipe_step/add_item/supermatter_sliver/check_conditions_met(obj/added_item, datum/cooking/recipe_tracker/tracker)
+	var/obj/item/retractor/supermatter/tongs = added_item
+	if(istype(tongs) && tongs.sliver)
+		return PCWJ_CHECK_VALID
+
+	var/obj/item/nuke_core/supermatter_sliver/sliver = added_item
+	if(istype(sliver))
+		return PCWJ_CHECK_VALID
+
+	return PCWJ_CHECK_INVALID
+
+/datum/cooking/recipe_step/add_item/supermatter_sliver/follow_step(obj/used_item, datum/cooking/recipe_tracker/tracker, mob/user)
+	var/obj/item/retractor/supermatter/tongs = used_item
+	if(istype(tongs) && tongs.sliver)
+		. = ..(tongs.sliver, tracker, user)
+		// TODO: refactor the tongs so they actually check if(sliver) in `update_icon()` instead of manually setting the icons everywhere.
+		tongs.sliver = null
+		tongs.update_appearance(UPDATE_ICON_STATE)
+	else
+		. = ..()
+
 /datum/cooking/recipe/supermatter_sandwich
 	container_type = /obj/item/reagent_containers/cooking/board
 	product_type = /obj/item/food/supermatter_sandwich
 	catalog_category = COOKBOOK_CATEGORY_BURGS
 	steps = list(
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/bread),
-		PCWJ_ADD_ITEM(/obj/item/nuke_core/supermatter_sliver),
+		new /datum/cooking/recipe_step/add_item/supermatter_sliver(),
 		PCWJ_ADD_ITEM(/obj/item/food/sliced/bread),
 	)
 


### PR DESCRIPTION
## What Does This PR Do
This PR converts the handling of supermatter slivers in recipes to a step.
## Why It's Good For The Game
- Keeps cooking container code ignorant of anything related to individual recipe items
- Isolates code responsible for handling tongs/slivers/updates
- Oblivion enforcers can now make a deli
- Another in-code example of unique recipe steps.
## Images of changes
<img width="365" height="312" alt="2025_10_03__09_15_10__Paradise Station 13" src="https://github.com/user-attachments/assets/fc0f596b-b3d9-4e3c-9e9a-739a0127157a" />